### PR TITLE
Add initial PowerShell WPF health center scaffolding

### DIFF
--- a/src/HealthCenter.psm1
+++ b/src/HealthCenter.psm1
@@ -1,0 +1,72 @@
+function Start-LoggedProcess {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$FilePath,
+        [string[]]$ArgumentList = @(),
+        [ScriptBlock]$LogAction
+    )
+
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $FilePath
+    $psi.Arguments = $ArgumentList -join ' '
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.UseShellExecute = $false
+    $psi.CreateNoWindow = $true
+
+    $proc = New-Object System.Diagnostics.Process
+    $proc.StartInfo = $psi
+    $proc.Start() | Out-Null
+
+    while (-not $proc.HasExited) {
+        $line = $proc.StandardOutput.ReadLine()
+        if ($line -ne $null -and $LogAction) {
+            & $LogAction $line
+        }
+    }
+    $proc.WaitForExit()
+
+    while (($line = $proc.StandardError.ReadLine()) -ne $null) {
+        if ($LogAction) {
+            & $LogAction $line
+        }
+    }
+
+    return $proc.ExitCode
+}
+
+function Invoke-SfcScan {
+    [CmdletBinding()]
+    param(
+        [ScriptBlock]$LogAction
+    )
+    Start-LoggedProcess -FilePath "sfc.exe" -ArgumentList '/scannow' -LogAction $LogAction | Out-Null
+}
+
+function Invoke-DismRestoreHealth {
+    [CmdletBinding()]
+    param(
+        [string]$Source,
+        [ScriptBlock]$LogAction
+    )
+    $args = @('/Online','/Cleanup-Image','/RestoreHealth')
+    if ($Source) {
+        $args += "/Source:$Source"
+        $args += '/LimitAccess'
+    }
+    Start-LoggedProcess -FilePath 'DISM.exe' -ArgumentList $args -LogAction $LogAction | Out-Null
+}
+
+function Parse-CbsLog {
+    [CmdletBinding()]
+    param(
+        [string]$LogPath = "$env:windir\\Logs\\CBS\\CBS.log"
+    )
+    if (-not (Test-Path $LogPath)) {
+        return @()
+    }
+    Get-Content $LogPath | Where-Object { $_ -like '*[SR]*' }
+}
+
+Export-ModuleMember -Function Start-LoggedProcess,Invoke-SfcScan,Invoke-DismRestoreHealth,Parse-CbsLog

--- a/src/REACT.ps1
+++ b/src/REACT.ps1
@@ -1,0 +1,39 @@
+Add-Type -AssemblyName PresentationFramework
+
+$script:AppRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+Import-Module "$AppRoot/HealthCenter.psm1" -Force
+
+[xml]$xaml = Get-Content "$AppRoot/REACT.xaml"
+$reader = (New-Object System.Xml.XmlNodeReader $xaml)
+$window = [Windows.Markup.XamlReader]::Load($reader)
+
+$RunSfcButton = $window.FindName('RunSfcButton')
+$RunFullRepairButton = $window.FindName('RunFullRepairButton')
+$UseLocalMediaCheckbox = $window.FindName('UseLocalMediaCheckbox')
+$CreateRestorePointCheckbox = $window.FindName('CreateRestorePointCheckbox')
+$LogBox = $window.FindName('LogBox')
+$ProgressBar = $window.FindName('ProgressBar')
+$StatusText = $window.FindName('StatusText')
+
+$appendLog = {
+    param($line)
+    $LogBox.AppendText($line + "`n")
+    $LogBox.ScrollToEnd()
+}
+
+$RunSfcButton.Add_Click({
+    $StatusText.Text = 'Running SFC...'
+    Invoke-SfcScan -LogAction $appendLog
+    $StatusText.Text = 'SFC completed.'
+})
+
+$RunFullRepairButton.Add_Click({
+    $StatusText.Text = 'Running DISM...'
+    $source = if ($UseLocalMediaCheckbox.IsChecked) { 'WIM:???' } else { $null }
+    Invoke-DismRestoreHealth -Source $source -LogAction $appendLog
+    $StatusText.Text = 'Running SFC...'
+    Invoke-SfcScan -LogAction $appendLog
+    $StatusText.Text = 'Full repair completed.'
+})
+
+$window.ShowDialog() | Out-Null

--- a/src/REACT.xaml
+++ b/src/REACT.xaml
@@ -1,0 +1,25 @@
+<Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="REACT - Windows Health Center" Height="400" Width="600">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="0,0,0,10">
+            <Button x:Name="RunSfcButton" Width="100" Margin="0,0,10,0">Run SFC Only</Button>
+            <Button x:Name="RunFullRepairButton" Width="120">Run Full Repair</Button>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Grid.Row="1" Margin="0,0,0,10">
+            <CheckBox x:Name="UseLocalMediaCheckbox" Margin="0,0,10,0">Use local media</CheckBox>
+            <CheckBox x:Name="CreateRestorePointCheckbox">Create restore point</CheckBox>
+        </StackPanel>
+        <TextBox x:Name="LogBox" Grid.Row="2" Margin="0,0,0,10" VerticalScrollBarVisibility="Auto" IsReadOnly="True" TextWrapping="Wrap"/>
+        <StackPanel Orientation="Horizontal" Grid.Row="3" VerticalAlignment="Bottom">
+            <ProgressBar x:Name="ProgressBar" Width="200" Height="20" Margin="0,0,10,0"/>
+            <TextBlock x:Name="StatusText" VerticalAlignment="Center"/>
+        </StackPanel>
+    </Grid>
+</Window>


### PR DESCRIPTION
## Summary
- set up HealthCenter PowerShell module with SFC and DISM helpers
- create WPF XAML UI skeleton with repair buttons and options
- wire up UI events in REACT.ps1 to call repair functions and log output

## Testing
- `apt-get update` *(fails: repository ... is not signed)*
- `pwsh -NoLogo -NoProfile -File src/REACT.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ba61a5ac1c832ea7a5dbeb8e60b3cf