### PR TITLE
feat: add toggleable console output

### DIFF
--- a/src/REACT.ps1
+++ b/src/REACT.ps1
@@ -14,12 +14,23 @@ $CreateRestorePointCheckbox = $window.FindName('CreateRestorePointCheckbox')
 $LogBox = $window.FindName('LogBox')
 $ProgressBar = $window.FindName('ProgressBar')
 $StatusText = $window.FindName('StatusText')
+$ToggleConsoleButton = $window.FindName('ToggleConsoleButton')
 
 $appendLog = {
     param($line)
     $LogBox.AppendText($line + "`n")
     $LogBox.ScrollToEnd()
 }
+
+$ToggleConsoleButton.Add_Click({
+    if ($LogBox.Visibility -eq 'Collapsed') {
+        $LogBox.Visibility = 'Visible'
+        $ToggleConsoleButton.Content = 'Hide Console'
+    } else {
+        $LogBox.Visibility = 'Collapsed'
+        $ToggleConsoleButton.Content = 'Show Console'
+    }
+})
 
 $RunSfcButton.Add_Click({
     $StatusText.Text = 'Running SFC...'

--- a/src/REACT.xaml
+++ b/src/REACT.xaml
@@ -16,10 +16,11 @@
             <CheckBox x:Name="UseLocalMediaCheckbox" Margin="0,0,10,0">Use local media</CheckBox>
             <CheckBox x:Name="CreateRestorePointCheckbox">Create restore point</CheckBox>
         </StackPanel>
-        <TextBox x:Name="LogBox" Grid.Row="2" Margin="0,0,0,10" VerticalScrollBarVisibility="Auto" IsReadOnly="True" TextWrapping="Wrap"/>
+        <TextBox x:Name="LogBox" Grid.Row="2" Margin="0,0,0,10" VerticalScrollBarVisibility="Auto" IsReadOnly="True" TextWrapping="Wrap" Visibility="Collapsed"/>
         <StackPanel Orientation="Horizontal" Grid.Row="3" VerticalAlignment="Bottom">
             <ProgressBar x:Name="ProgressBar" Width="200" Height="20" Margin="0,0,10,0"/>
             <TextBlock x:Name="StatusText" VerticalAlignment="Center"/>
+            <Button x:Name="ToggleConsoleButton" Margin="10,0,0,0">Show Console</Button>
         </StackPanel>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- hide console log area by default and add button to show it
- wire up toggle functionality in PowerShell script

## Testing
- ⚠️ `pwsh -NoLogo -NoProfile -File src/REACT.ps1` *(missing dependency: pwsh)*


------
https://chatgpt.com/codex/tasks/task_b_68ba65d01cdc832e8375bda7cc75900d