### PR TITLE
feat: log SFC output and parse CBS log

### DIFF
--- a/src/HealthCenter.psm1
+++ b/src/HealthCenter.psm1
@@ -27,6 +27,11 @@ function Start-LoggedProcess {
     }
     $proc.WaitForExit()
 
+    while (($line = $proc.StandardOutput.ReadLine()) -ne $null) {
+        if ($LogAction) {
+            & $LogAction $line
+        }
+    }
     while (($line = $proc.StandardError.ReadLine()) -ne $null) {
         if ($LogAction) {
             & $LogAction $line
@@ -41,7 +46,12 @@ function Invoke-SfcScan {
     param(
         [ScriptBlock]$LogAction
     )
+    if ($LogAction) { & $LogAction 'Running: sfc /scannow' }
     Start-LoggedProcess -FilePath "sfc.exe" -ArgumentList '/scannow' -LogAction $LogAction | Out-Null
+    if ($LogAction) { & $LogAction 'SFC scan complete. Parsing CBS log...' }
+    foreach ($line in Parse-CbsLog) {
+        if ($LogAction) { & $LogAction $line }
+    }
 }
 
 function Invoke-DismRestoreHealth {


### PR DESCRIPTION
## Summary
- Capture remaining stdout and stderr when running health checks
- Log SFC execution and parse CBS log for diagnostics

## Testing
- `pwsh -NoProfile -Command "Import-Module ./src/HealthCenter.psm1; Get-Command Invoke-SfcScan"`
- `pwsh -NoProfile -Command "Import-Module ./src/HealthCenter.psm1; Invoke-SfcScan -LogAction {param($l) Write-Host $l}" 2>&1 | head -n 20` *(fails: sfc.exe not found)*


------
https://chatgpt.com/codex/tasks/task_b_68bc63bd329c832ea2702da6bcfff5ec